### PR TITLE
Allow mock LED driver via config

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,14 +1,14 @@
 # app.py
 from flask import Flask, render_template, request, jsonify, send_from_directory
 from effects import apply_scene
-from controller.led_driver import init_strip, apply_color, apply_fade
+from controller.config import get_led_driver
 import json
 import os
 import threading
 import time
 
 app = Flask(__name__)
-strip = init_strip()
+strip, apply_color, apply_fade = get_led_driver()
 
 SCENES_DIR = 'scenes'
 

--- a/controller/config.py
+++ b/controller/config.py
@@ -9,12 +9,10 @@ GLOBAL_BRIGHTNESS = 31
 SPI_SPEED_HZ = 12000000
 
 def get_led_driver():
-    """
-    Returns the appropriate LED driver based on configuration.
-    """
+    """Return initialized strip object and helpers based on configuration."""
     if USE_MOCK_DRIVER:
         from .mock_led_driver import init_strip, apply_color, apply_fade
     else:
         from .led_driver import init_strip, apply_color, apply_fade
-    
-    return init_strip(), apply_color, apply_fade 
+
+    return init_strip(), apply_color, apply_fade

--- a/effects/__init__.py
+++ b/effects/__init__.py
@@ -2,14 +2,16 @@ import json
 import math
 import random
 import time
-from controller.led_driver import apply_color, apply_fade, LED_COUNT
+from controller.config import get_led_driver, LED_COUNT
+
+_, apply_color, apply_fade = get_led_driver()
 
 def effect_solid(strip, color, duration, **kwargs):
     apply_color(strip, color)
     time.sleep(duration)
 
 def effect_gradient(strip, color_start, color_end, duration, **kwargs):
-    steps = LED_COUNT
+    steps = strip.num_led
     for i in range(steps):
         t = i / (steps - 1)
         r = int(color_start[0] + (color_end[0] - color_start[0]) * t)
@@ -31,8 +33,8 @@ def effect_breathing(strip, base_color, cycle_s, duration, **kwargs):
 def effect_pulse(strip, color, speed, width_px, duration, **kwargs):
     steps = int(duration * 30)
     for i in range(steps):
-        pos = int((i * speed / 30) % LED_COUNT)
-        for j in range(LED_COUNT):
+        pos = int((i * speed / 30) % strip.num_led)
+        for j in range(strip.num_led):
             if abs(j - pos) < width_px // 2:
                 strip.set_pixel(j, *color)
             else:
@@ -54,8 +56,8 @@ def effect_strobe(strip, color, duty_cycle, tempo, duration, **kwargs):
 def effect_chase(strip, color, speed, duration, **kwargs):
     steps = int(duration * 30)
     for i in range(steps):
-        pos = int((i * speed / 30) % LED_COUNT)
-        for j in range(LED_COUNT):
+        pos = int((i * speed / 30) % strip.num_led)
+        for j in range(strip.num_led):
             if j == pos:
                 strip.set_pixel(j, *color)
             else:
@@ -73,7 +75,7 @@ def transition_instant(strip, from_color, to_color, **kwargs):
 def transition_wave(strip, from_color, to_color, duration, wavelength_px=20, speed=1, **kwargs):
     steps = int(duration * 30)
     for t in range(steps):
-        for i in range(LED_COUNT):
+        for i in range(strip.num_led):
             phase = 2 * math.pi * (i / wavelength_px - speed * t / steps)
             mix = 0.5 + 0.5 * math.sin(phase)
             color = [int(from_color[j] + (to_color[j] - from_color[j]) * mix) for j in range(3)]
@@ -83,10 +85,10 @@ def transition_wave(strip, from_color, to_color, duration, wavelength_px=20, spe
 
 def transition_middle_out(strip, from_color, to_color, duration, **kwargs):
     steps = int(duration * 30)
-    mid = LED_COUNT // 2
+    mid = strip.num_led // 2
     for t in range(steps):
         spread = int((t / steps) * mid)
-        for i in range(LED_COUNT):
+        for i in range(strip.num_led):
             if abs(i - mid) <= spread:
                 strip.set_pixel(i, *to_color)
             else:
@@ -97,7 +99,7 @@ def transition_middle_out(strip, from_color, to_color, duration, **kwargs):
 def transition_random_shimmer(strip, from_color, to_color, duration, jitter_pct=0.05, **kwargs):
     steps = int(duration * 30)
     for t in range(steps):
-        for i in range(LED_COUNT):
+        for i in range(strip.num_led):
             mix = t / steps
             base = [int(from_color[j] + (to_color[j] - from_color[j]) * mix) for j in range(3)]
             jitter = [min(255, max(0, int(c + random.uniform(-jitter_pct, jitter_pct) * 255))) for c in base]


### PR DESCRIPTION
## Summary
- support selecting LED driver from `controller.config`
- initialize LED helper functions from config
- update effects to rely on `strip.num_led` instead of fixed `LED_COUNT`

## Testing
- `pip install -r requirements.txt`
- `pip install pygame`
- `python -m py_compile app.py effects/__init__.py controller/config.py`

------
https://chatgpt.com/codex/tasks/task_e_684294c14abc832cb336af034f188156